### PR TITLE
 	detect and link against lapack libraries. use cython with monkey patch.

### DIFF
--- a/monkey.py
+++ b/monkey.py
@@ -1,0 +1,49 @@
+import os.path
+import os
+from distutils.dep_util import newer_group
+from distutils.errors import DistutilsError
+from numpy.distutils.misc_util import appendpath
+from numpy.distutils import log
+
+def have_cython():
+  try:
+    import Cython
+  except ImportError:
+    return False
+  return True
+
+def generate_a_cython_source(self, base, ext_name, source, extension):
+        if self.inplace or not have_cython():
+            target_dir = os.path.dirname(base)
+        else:
+            target_dir = appendpath(self.build_src, os.path.dirname(base))
+        target_file = os.path.join(target_dir, ext_name + '.c')
+        depends = [source] + extension.depends
+        if self.force or newer_group(depends, target_file, 'newer'):
+            if have_cython():
+                import Cython.Compiler.Main
+                log.info("cythonc:> %s: %s " % (target_dir, target_file))
+                log.info("cwd %s " % (os.getcwd()))
+                self.mkpath(target_dir)
+                options = Cython.Compiler.Main.CompilationOptions(
+                    defaults=Cython.Compiler.Main.default_options,
+                    include_path=extension.include_dirs,
+                    output_file=target_file)
+                #log.info('\n'.join([s + ' ' + str(getattr(options, s)) for s in dir(options)]))
+                # avoid calling compile_single, because it will give wrong module names.
+                cython_result = Cython.Compiler.Main.compile([source],
+                                                           options=options)
+                if cython_result.num_errors != 0:
+                    raise DistutilsError("%d errors while compiling %r with Cython" \
+                          % (cython_result.num_errors, source))
+            elif os.path.isfile(target_file):
+                log.warn("Cython required for compiling %r but not available,"\
+                         " using old target %r"\
+                         % (source, target_file))
+            else:
+                raise DistutilsError("Cython required for compiling %r"\
+                                     " but notavailable" % (source,))
+        return target_file
+
+from numpy.distutils.command import build_src
+build_src.build_src.generate_a_pyrex_source = generate_a_cython_source

--- a/scikits/sparse/cholmod.pyx
+++ b/scikits/sparse/cholmod.pyx
@@ -29,8 +29,8 @@
 # SUCH DAMAGE.
 
 import warnings
-cimport stdlib
-cimport python as py
+from libc cimport stdlib
+cimport cpython as py
 import numpy as np
 cimport numpy as np
 from scipy import sparse
@@ -72,7 +72,7 @@ cdef inline np.ndarray set_base(np.ndarray arr, object base):
     hack.base = <void *> base
     return arr
 
-cdef extern from "suitesparse/cholmod.h":
+cdef extern from "cholmod.h":
     cdef enum:
         CHOLMOD_INT
         CHOLMOD_PATTERN, CHOLMOD_REAL, CHOLMOD_COMPLEX

--- a/setup.py
+++ b/setup.py
@@ -26,22 +26,29 @@ LICENSE             = 'GPL'
 DOWNLOAD_URL        = "https://github.com/njsmith/scikits-sparse/downloads"
 VERSION             = '0.1+dev'
 
-# Add our fake Pyrex at the end of the Python search path
-# in order to fool setuptools into allowing compilation of
-# pyx files to C files. Importing Cython.Distutils then
-# makes Cython the tool of choice for this rather than
-# (the possibly nonexisting) Pyrex.
-project_path = os.path.split(__file__)[0]
-sys.path.append(os.path.join(project_path, 'fake_pyrex'))
+from numpy.distutils.core import setup, Extension
+from numpy.distutils.system_info import lapack_info, lapack_mkl_info
 
-from setuptools import setup, find_packages, Extension
-from Cython.Distutils import build_ext
+lapack_libs = []
+lapack_lib_dirs = []
+lapack_include_dirs = []
+for l in [lapack_mkl_info().get_info(), lapack_info().get_info()]:
+  try:
+    lapack_libs += l['libraries']
+    lapack_lib_dirs += l['library_dirs']
+    lapack_include_dirs += l['include_dirs']
+    break
+  except:
+    pass
+
 import numpy as np
+# the monkey patch trick so that cython is called on pyx files.
+import monkey
 
 if __name__ == "__main__":
     setup(install_requires = ['numpy', 'scipy'],
           namespace_packages = ['scikits'],
-          packages = find_packages(),
+          packages = ['scikits.sparse'], #find_packages(),
           package_data = {
               "": ["*.mtx.gz"],
               },
@@ -66,16 +73,14 @@ if __name__ == "__main__":
               'Intended Audience :: Science/Research',
               'License :: OSI Approved :: GNU General Public License (GPL)',
               'Topic :: Scientific/Engineering'],
-          cmdclass = {"build_ext": build_ext},
           ext_modules = [
               Extension("scikits.sparse.cholmod",
                         ["scikits/sparse/cholmod.pyx"],
-                        libraries=["cholmod"],
-                        include_dirs=[np.get_include()],
+                        libraries=["cholmod", "colamd", "amd", "suitesparseconfig", 'rt'] + lapack_libs,
+                        include_dirs=[np.get_include()] + lapack_include_dirs,
                         # If your CHOLMOD is in a funny place, you may need to
-                        # add something like this:
-                        #library_dirs=["/opt/suitesparse/lib"],
-                        # And modify include_dirs above in a similar way.
+                        # add some LDFLAGS and CFLAGS before running setup
+                        library_dirs=lapack_lib_dirs,
                         ),
               ],
           )


### PR DESCRIPTION
Just a few issues to be reviewed:

I am not sure if this is a bug or not, but 
I receive 'unresolved symbol' errors unless I link against all of the lapack libraries, explicitly. Everything is properly configured though. I use an old mkl.

Also the default path prefix of cholmod header is quite unflexible -- what if it is installed to /opt/SuiteSparse(eg, our machine's default installation)

I also dropped in a monkey patch to replace the .pyx handler with Cython. You may find it quite ugly.

