### PR TITLE
Changed setup.py to use distutils as setuptools is incompatible with Cython.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,14 +34,15 @@ VERSION             = '0.1+dev'
 project_path = os.path.split(__file__)[0]
 sys.path.append(os.path.join(project_path, 'fake_pyrex'))
 
-from setuptools import setup, find_packages, Extension
+from distutils.core import setup
+from distutils.extension import Extension
 from Cython.Distutils import build_ext
 import numpy as np
 
 if __name__ == "__main__":
     setup(install_requires = ['numpy', 'scipy'],
           namespace_packages = ['scikits'],
-          packages = find_packages(),
+          packages = ['scikits', 'scikits.sparse'],
           package_data = {
               "": ["*.mtx.gz"],
               },


### PR DESCRIPTION
When doing pip install scikits.sparse I get:

```
Installing collected packages: scikits.sparse
  Running setup.py install for scikits.sparse
    building 'scikits.sparse.cholmod' extension
    gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -I/home/whyking/envs/pymc3/local/lib/python2.7/site-packages/numpy/core/include -I/usr/include/python2.7 -c scikits/sparse/cholmod.c -o build/temp.linux-i686-2.7/scikits/sparse/cholmod.o
    gcc: error: scikits/sparse/cholmod.c: No such file or directory
    gcc: fatal error: no input files
    compilation terminated.
    error: command 'gcc' failed with exit status 4
```

I had the same problem with another package and the reason is that setuptools does not work correctly with cython (the .c file is not getting created). This PR replaces setuptools with distutils which fixes this problem. Generally speaking, usage of setuptools should be avoided as current opinions go.
