### PR TITLE
Fix glob for test data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ if __name__ == "__main__":
           namespace_packages = ['scikits'],
           packages = find_packages(),
           package_data = {
-              "": ["*.mtx.gz"],
+              "": ["test_data/*.mtx.gz"],
               },
           test_suite="nose.collector",
           # Well, technically zipping the package will work, but since it's


### PR DESCRIPTION
The test data was not being included in builds or installs because the
glob was looking non-recursively for files under scikits/sparse, rather
than under scikits/sparse/test_data.
