### PR TITLE
make setup.py not rely on an installed cython

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ addons:
         packages:
             - libsuitesparse-dev
 install:
-    - pip install cython scipy
+    - pip install 'setuptools>=18' 'scipy'
     - python setup.py build_ext --inplace
 script: py.test

--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,6 @@
 name: py35
 dependencies:
     - python=3.5.2
-    - cython=0.24.1
     - scipy=0.18.0
     - pip:
         - sphinx==1.4.5

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ URL                 = 'https://github.com/scikit-sparse/scikit-sparse/'
 LICENSE             = 'GPL'
 
 from setuptools import setup, find_packages, Extension
-from Cython.Build import cythonize
 import numpy as np
 import versioneer
 
@@ -50,9 +49,11 @@ if __name__ == "__main__":
               'Intended Audience :: Science/Research',
               'License :: OSI Approved :: GNU General Public License (GPL)',
               'Topic :: Scientific/Engineering'],
+          setup_requires=['setuptools>=18.0', 'numpy', 'cython'],
           # You may specify the directory where CHOLMOD is installed using the
-          # include_path and library_dirs distutils directives at the top of
-          # cholmod.pyx.
-          ext_modules = cythonize(
-              "sksparse/cholmod.pyx",
-              aliases={"NP_GET_INCLUDE": np.get_include()}))
+          # library_dirs and include_dirs keywords in the lines below.
+          ext_modules = [Extension("sksparse.cholmod", ["sksparse/cholmod.pyx"],
+              include_dirs=[np.get_include(), '/usr/include/suitesparse'],
+              library_dirs=[],
+              libraries=['cholmod'])],
+          )

--- a/sksparse/cholmod.pyx
+++ b/sksparse/cholmod.pyx
@@ -31,8 +31,6 @@
 
 #cython: binding = True
 #cython: language_level = 3
-#distutils: include_dirs = NP_GET_INCLUDE /usr/include/suitesparse
-#distutils: libraries = cholmod
 
 cimport numpy as np
 


### PR DESCRIPTION
Referencing to issue #20, I tried to make `setup.py` not to rely on an installed `cython`.

The installation worked with an installed `cython`. Without `cython` installed, it installs `cython`. In my case, unfortunately, an error occurs in this process which seams to be related to the Intel compiler `icc` and not to `scikit-sparse` or `cython`.
```
": internal error: 010101_(5000 + 54)
icc: error #10014: problem during multi-file optimization compilation (code 4)
```
Maybe you can check if its working for you without `cython` installed?

Besides, `setup.py` still relies on an installed `numpy`.