### PR TITLE
ENH: support for indices of type long added

### DIFF
--- a/sksparse/cholmod_backward_compatible.h
+++ b/sksparse/cholmod_backward_compatible.h
@@ -3,5 +3,20 @@
 // CHOLMOD_GPU_PROBLEM is only defined since version 2.0 of cholmod,
 // so we need to define it here for backward compatibility
 #ifndef CHOLMOD_GPU_PROBLEM
-#define CHOLMOD_GPU_PROBLEM -5
+    #define CHOLMOD_GPU_PROBLEM -5
+#endif
+
+// SuiteSparse_long is only defined since version 4.0 of cholmod,
+// previously its name was UF_long,
+// so we need to define it here for backward compatibility
+#ifndef SuiteSparse_long
+    #ifdef UF_long
+        #define SuiteSparse_long UF_long
+    #else
+        #ifdef _WIN64
+            #define SuiteSparse_long __int64
+        #else
+            #define SuiteSparse_long long
+        #endif
+    #endif
 #endif


### PR DESCRIPTION
A support for indices of type `long` is added. This allows to handle big matrices (more than 2^31 entries or dimension larger then 2^31). The needed index type is determined automatically by default or can be passed explicitly.

(Furthermore `Factor._print` is added analogous to `Common._print`)