### PR TITLE
Python 3.6 support, NumPy 1.11 and 1.12 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,16 @@
 language: python
-python: ['2.7', '3.5', '3.6']
+python: ['2.7', '3.4', '3.5', '3.6']
+env:
+    - NUMPY='numpy>=1.8.0<1.9.0'
+    - NUMPY='numpy>=1.9.0<1.10.0'
+    - NUMPY='numpy>=1.10.0<1.11.0'
+    - NUMPY='numpy>=1.11.0<1.12.0'
+    - NUMPY='numpy>=1.12.0<1.13.0'
 addons:
     apt:
         packages:
             - libsuitesparse-dev
 install:
-    - pip install 'setuptools>=18' 'scipy'
+    - pip install 'setuptools>=18' $NUMPY 'scipy'
     - python setup.py build_ext --inplace
 script: py.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-python: ["2.7", "3.5"]
+python: ['2.7', '3.5', '3.6']
 addons:
     apt:
         packages:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ![Python27](https://img.shields.io/badge/python-2.7-blue.svg)
 ![Python35](https://img.shields.io/badge/python-3.5-blue.svg)
+![Python36](https://img.shields.io/badge/python-3.6-blue.svg)
 [![Documentation Status](https://readthedocs.org/projects/scikit-sparse/badge/?version=latest)](http://scikit-sparse.readthedocs.io/en/latest/?badge=latest)
 [![Travis](https://travis-ci.org/scikit-sparse/scikit-sparse.svg?branch=master)](https://travis-ci.org/scikit-sparse/scikit-sparse)
 

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ that if you, for example, buy a license to use CHOLMOD in a commercial
 product, then you can also go ahead and use our wrapper code with your
 commercial license.)
 
-Copyright (c) 2009-2016, the [scikit-sparse developers](https://scikit-sparse.readthedocs.io/en/latest/overview.html#developers)
+Copyright (c) 2009-2017, the [scikit-sparse developers](https://scikit-sparse.readthedocs.io/en/latest/overview.html#developers)
 
     scikits-sparse
-    Copyright (c) 2009-2016, the scikit-sparse developers
+    Copyright (c) 2009-2017, the scikit-sparse developers
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -3,6 +3,11 @@ Changes
 
 .. module:: sksparse.cholmod
 
+v0.4.1
+------
+  * Bug with relaxed stride checking in NumPy 1.12 fixed.
+  * Support extended to Python 2.7 and 3.4 to 3.6 and NumPy 1.8 to 1.12.
+
 v0.4
 ------
   * 64-bit indices (type long) are now supported.

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -41,7 +41,7 @@ Requirements
 Installing :mod:`scikit-sparse` requires:
 
 * `Python <http://python.org/>`_
-  (2.7 or 3.5 -- older versions may work but are untested)
+  (2.7, 3.5 or 3.6) -- other versions may work but are untested)
 * `NumPy <http://numpy.scipy.org/>`_
 * `SciPy <http://www.scipy.org/>`_
 * `Cython <http://www.cython.org/>`_

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -41,8 +41,9 @@ Requirements
 Installing :mod:`scikit-sparse` requires:
 
 * `Python <http://python.org/>`_
-  (2.7, 3.5 or 3.6) -- other versions may work but are untested)
+  (2.7, 3.4, 3.5 or 3.6 -- other versions may work but are untested)
 * `NumPy <http://numpy.scipy.org/>`_
+  (1.8 to 1.12 -- other versions may work but are untested)
 * `SciPy <http://www.scipy.org/>`_
 * `Cython <http://www.cython.org/>`_
 * `CHOLMOD <http://www.cise.ufl.edu/research/sparse/cholmod/>`_

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -76,6 +76,6 @@ Developers
 * 2010        `Dag Sverre Seljebotn    <dagss@student.matnat.uio.no>`_
 * 2014        `Leon Barrett            <lbarrett@climate.com>`_
 * 2015        `Yuri                    <yuri@tsoft.com>`_
-* 2016        `Antony Lee              <anntzer.lee@gmail.com>`_
+* 2016-2017   `Antony Lee              <anntzer.lee@gmail.com>`_
 * 2016        `Alex Grigorievskiy      <alex.grigorievskiy@gmail.com>`_
-* 2016        `Joscha Reimer           <jor@informatik.uni-kiel.de>`_
+* 2016-2017   `Joscha Reimer           <jor@informatik.uni-kiel.de>`_

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,15 @@
 #! /usr/bin/env python
 
-# Copyright (C) 2008-2016 The scikit-sparse developers:
-#
+# Copyright (C) 2008-2017 The scikit-sparse developers:
+# 
 # 2008        David Cournapeau        <cournape@gmail.com>
 # 2009-2015   Nathaniel Smith         <njs@pobox.com>
 # 2010        Dag Sverre Seljebotn    <dagss@student.matnat.uio.no>
 # 2014        Leon Barrett            <lbarrett@climate.com>
 # 2015        Yuri                    <yuri@tsoft.com>
-# 2016        Antony Lee              <anntzer.lee@gmail.com>
+# 2016-2017   Antony Lee              <anntzer.lee@gmail.com>
 # 2016        Alex Grigorievskiy      <alex.grigorievskiy@gmail.com>
-# 2016        Joscha Reimer           <jor@informatik.uni-kiel.de>
+# 2016-2017   Joscha Reimer           <jor@informatik.uni-kiel.de>
 
 """Sparse matrix tools.
 

--- a/sksparse/cholmod.pyx
+++ b/sksparse/cholmod.pyx
@@ -1,7 +1,15 @@
 # CHOLMOD wrapper for scikits.sparse
 
-# Copyright (C) 2009 Nathaniel Smith <njs@pobox.com>
-# Copyright (C) 2016 Antony Lee <anntzer.lee@gmail.com>
+# Copyright (C) 2008-2017 The scikit-sparse developers:
+# 
+# 2008        David Cournapeau        <cournape@gmail.com>
+# 2009-2015   Nathaniel Smith         <njs@pobox.com>
+# 2010        Dag Sverre Seljebotn    <dagss@student.matnat.uio.no>
+# 2014        Leon Barrett            <lbarrett@climate.com>
+# 2015        Yuri                    <yuri@tsoft.com>
+# 2016-2017   Antony Lee              <anntzer.lee@gmail.com>
+# 2016        Alex Grigorievskiy      <alex.grigorievskiy@gmail.com>
+# 2016-2017   Joscha Reimer           <jor@informatik.uni-kiel.de>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/sksparse/test_cholmod.py
+++ b/sksparse/test_cholmod.py
@@ -1,7 +1,7 @@
 # Test code for the scikits.sparse CHOLMOD wrapper.
 
 # Copyright (C) 2008-2017 The scikit-sparse developers:
-# 
+#
 # 2008        David Cournapeau        <cournape@gmail.com>
 # 2009-2015   Nathaniel Smith         <njs@pobox.com>
 # 2010        Dag Sverre Seljebotn    <dagss@student.matnat.uio.no>
@@ -39,7 +39,6 @@
 
 from functools import partial
 import os.path
-import warnings
 
 from nose.tools import assert_raises
 import numpy as np

--- a/sksparse/test_cholmod.py
+++ b/sksparse/test_cholmod.py
@@ -1,7 +1,15 @@
 # Test code for the scikits.sparse CHOLMOD wrapper.
 
-# Copyright (C) 2009 Nathaniel Smith <njs@pobox.com>
-# Copyright (C) 2016 Antony Lee <anntzer.lee@gmail.com>
+# Copyright (C) 2008-2017 The scikit-sparse developers:
+# 
+# 2008        David Cournapeau        <cournape@gmail.com>
+# 2009-2015   Nathaniel Smith         <njs@pobox.com>
+# 2010        Dag Sverre Seljebotn    <dagss@student.matnat.uio.no>
+# 2014        Leon Barrett            <lbarrett@climate.com>
+# 2015        Yuri                    <yuri@tsoft.com>
+# 2016-2017   Antony Lee              <anntzer.lee@gmail.com>
+# 2016        Alex Grigorievskiy      <alex.grigorievskiy@gmail.com>
+# 2016-2017   Joscha Reimer           <jor@informatik.uni-kiel.de>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
I added Python 3.6 to the tests and thus to the supported Python versions in scikit-sparse.

Furthermore I added explicit NumPy versions to the test and thus to the support NumPy versions in scikit-sparse. This might help to find problems with specific NumPy versions like for example in issue #27.

(I also updated the years in the copyright.)

@anntzer: Might you review this?