### PR TITLE
Pin to cython<0.29; avoid repeated np.matrix PendingDeprecationWarnings.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,7 @@ versionfile_source = sksparse/_version.py
 versionfile_build = sksparse/_version.py
 tag_prefix = v
 parentdir_prefix = sksparse-
+
+[tool:pytest]
+# Don't be drowned under PendingDeprecationWarnings for np.matrix.
+filterwarnings = once::PendingDeprecationWarning

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
              'Programming Language :: Cython',
              'Topic :: Scientific/Engineering',
              'Topic :: Scientific/Engineering :: Mathematics'],
-          setup_requires = ['setuptools>=18.0', 'numpy', 'cython'],
+          setup_requires = ['setuptools>=18.0', 'numpy', 'cython<0.29'],
           # You may specify the directory where CHOLMOD is installed using the
           # library_dirs and include_dirs keywords in the lines below.
           ext_modules = [


### PR DESCRIPTION
Not optimal, but better than a broken build and thousands of repeated
warnings.

Closes #49.