### PR TITLE
release version 0.4.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,43 @@
 language: python
-python: ['3.6', '3.5', '2.7']
 env:
     matrix:
-        - NUMPY_VERSION='==1.14.*' SCIPY_VERSION='==1.0.*'
-        - NUMPY_VERSION='==1.14.*' SCIPY_VERSION='==0.19.*'
-        - NUMPY_VERSION='==1.13.*' SCIPY_VERSION='==1.0.*'
-        - NUMPY_VERSION='==1.13.*' SCIPY_VERSION='==0.19.*'
-addons:
-    apt:
-        packages:
-            - libsuitesparse-dev
+        - PYTHON=3.7 NUMPY=1.15 SCIPY=1.1 SUITESPARSE=5.2
+        - PYTHON=3.7 NUMPY=1.15 SCIPY=1.0 SUITESPARSE=5.2
+        - PYTHON=3.7 NUMPY=1.15 SCIPY=0.19 SUITESPARSE=5.2
+        - PYTHON=3.7 NUMPY=1.14 SCIPY=1.1 SUITESPARSE=5.2
+        - PYTHON=3.7 NUMPY=1.14 SCIPY=1.0 SUITESPARSE=5.2
+        - PYTHON=3.7 NUMPY=1.14 SCIPY=0.19 SUITESPARSE=5.2
+        - PYTHON=3.7 NUMPY=1.13 SCIPY=1.1 SUITESPARSE=5.2
+        - PYTHON=3.7 NUMPY=1.13 SCIPY=1.0 SUITESPARSE=5.2
+        - PYTHON=3.7 NUMPY=1.13 SCIPY=0.19 SUITESPARSE=5.2
+        - PYTHON=3.6 NUMPY=1.15 SCIPY=1.1 SUITESPARSE=5.2
+        - PYTHON=3.6 NUMPY=1.15 SCIPY=1.0 SUITESPARSE=5.2
+        - PYTHON=3.6 NUMPY=1.15 SCIPY=0.19 SUITESPARSE=5.2
+        - PYTHON=3.6 NUMPY=1.14 SCIPY=1.1 SUITESPARSE=5.2
+        - PYTHON=3.6 NUMPY=1.14 SCIPY=1.0 SUITESPARSE=5.2
+        - PYTHON=3.6 NUMPY=1.14 SCIPY=0.19 SUITESPARSE=5.2
+        - PYTHON=3.6 NUMPY=1.13 SCIPY=1.1 SUITESPARSE=5.2
+        - PYTHON=3.6 NUMPY=1.13 SCIPY=1.0 SUITESPARSE=5.2
+        - PYTHON=3.6 NUMPY=1.13 SCIPY=0.19 SUITESPARSE=5.2
 install:
-    - pip install 'setuptools>=18' 'numpy'$NUMPY_VERSION 'scipy'$SCIPY_VERSION
-    - pip list
+    # install conda
+    - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+    - bash miniconda.sh -b -p $HOME/miniconda
+    - . $HOME/miniconda/etc/profile.d/conda.sh
+    - conda config --set always_yes yes --set changeps1 no
+    - conda update -q conda
+    - conda info -a
+    # create test environment
+    - conda create -q -n test-environment
+    - conda activate test-environment
+    # install needed packages
+    - conda install -q python=$PYTHON
+    - conda install -q numpy=$NUMPY
+    - conda install -q scipy=$SCIPY
+    - conda install -q suitesparse=$SUITESPARSE
+    - conda install -q nose
+    - conda list
+    # install this package
     - python setup.py build_ext --inplace
-script: py.test
+script:
+    - nosetests -sv sksparse

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,10 @@
-include README
+include LICENSE.txt
+include README.md
 global-include *.h *.pyx *.mtx.gz
 graft doc
 prune doc/_build
-prune build dist
+prune build
+prune dist
 global-exclude *~ *.so *.pyc
 include versioneer.py
 include sksparse/_version.py

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,7 +6,10 @@ Changes
 v0.4.3
 ------
   * The method `solve_L` can now also use the `L` matrix of the LL' decomposition.
-  * Supported versions updated to Python 3.6, 3.5 and 2.7, NumPy 1.14 and 1.13 and SciPy 1.0 and 0.19.
+  * Supported versions updated to:
+    - Python: 3.6, 3.5
+    - NumPy: 1.14, 1.13
+    - SciPy: 1.0, 0.19
 
 v0.4.2
 ------
@@ -16,13 +19,15 @@ v0.4.2
 v0.4.1
 ------
   * Bug with relaxed stride checking in NumPy 1.12 fixed.
-  * Support extended to Python 2.7 and 3.4 to 3.6 and NumPy 1.8 to 1.12.
+  * Supported versions updated to:
+    - Python: 3.6, 3.5, 3.4, 2.7
+    - NumPy: 1.8 to 1.12
 
 v0.4
 ------
   * 64-bit indices (type long) are now supported.
   * The ordering method for Cholesky decomposition is now choosable.
-  * Specific exceptions subclasses are now thrown for each error condition
+  * Specific exceptions subclasses are now thrown for each error condition.
   * Setup does not rely on an installed Cython anymore.
 
 v0.3.1

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -3,6 +3,16 @@ Changes
 
 .. module:: sksparse.cholmod
 
+v0.4.4
+------
+  * Bug in solve with dense array, where base of result is not set correctly, fixed.
+  * Travis tests are using conda now.
+  * Supported versions updated to:
+    - Python: 3.7, 3.6
+    - NumPy: 1.15, 1.14, 1.13
+    - SciPy: 1.1, 1.0, 0.19
+    - SuiteSparse: 5.2
+
 v0.4.3
 ------
   * The method `solve_L` can now also use the `L` matrix of the LL' decomposition.

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -41,13 +41,17 @@ Requirements
 Installing :mod:`scikit-sparse` requires:
 
 * `Python <http://python.org/>`_
-  (3.6, 3.5 or 2.7 -- other versions may work but are untested)
 * `NumPy <http://numpy.scipy.org/>`_
-  (1.14 or 1.13 -- other versions may work but are untested)
 * `SciPy <http://www.scipy.org/>`_
-  (1.0 or 0.19 -- other versions may work but are untested)
 * `Cython <http://www.cython.org/>`_
 * CHOLMOD (included in `SuiteSparse <http://www.suitesparse.com>`_)
+
+Test versions are:
+* Python: 3.7, 3.6
+* NumPy: 1.15, 1.14, 1.13
+* SciPy: 1.1, 1.0, 0.19
+* SuiteSparse: 5.2
+(Other versions may work but are untested.)
 
 On Debian/Ubuntu systems, the following command should suffice::
 

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -68,6 +68,10 @@ As usual, ::
 
   $ pip install --user scikit-sparse
 
+or with conda ::
+
+  $ conda install -c conda-forge scikit-sparse
+
 Contact
 -------
 


### PR DESCRIPTION
I would like to release version 0.4.4. It fixes the bug in `solve`, where the `base` attribute of the result array is not set correctly. Besides this the tests are now using conda.