### PR TITLE
Fix SuiteSparse include and library directories on macOS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,8 +76,14 @@ setup(
                 # Debian's suitesparse-dev installs to
                 # /usr/include/suitesparse
                 "/usr/include/suitesparse",
+                # macOS's suitesparse installs to
+                # /usr/local/include/suitesparse
+                "/usr/local/include/suitesparse",
             ],
-            library_dirs=[],
+            library_dirs=[
+                # macOS's suitesparse installs to /usr/local/lib
+                "/usr/local/lib",
+            ],
             libraries=["cholmod"],
         )
     ),


### PR DESCRIPTION
SuiteSparse on macOS is installed to `/usr/local/include/suitesparse` and `/usr/local/lib` when installed using `brew install suitesparse`. I added both of these to `setup.py`. 

Fixes issue https://github.com/scikit-sparse/scikit-sparse/issues/67.

Built and tested this on macOS 11.5.2.