### PR TITLE
Adding environment variables for easier intall

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,7 @@ Thumbs.db
 
 # virtual environments
 venv
+
+# vscode
+.devcontainer/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/scikit-sparse/scikit-sparse)](https://github.com/scikit-sparse/scikit-sparse/releases/latest)
 [![PyPI](https://img.shields.io/pypi/v/scikit-sparse)](https://pypi.org/project/scikit-sparse/)
 [![Conda Version](https://img.shields.io/conda/vn/conda-forge/scikit-sparse.svg)](https://anaconda.org/conda-forge/scikit-sparse)
-[![GitHub Workflow Status (event)](https://img.shields.io/github/workflow/status/scikit-sparse/scikit-sparse/CI%20targets?label=CI%20Tests)](https://github.com/scikit-sparse/scikit-sparse/actions/workflows/ci_test.yml) 
+[![GitHub Workflow Status (event)](https://img.shields.io/github/workflow/status/scikit-sparse/scikit-sparse/CI%20targets?label=CI%20Tests)](https://github.com/scikit-sparse/scikit-sparse/actions/workflows/ci_test.yml)
 [![Python Versions](https://img.shields.io/badge/python-3.6%2C%203.7%2C%203.8%2C%203.9-blue.svg)]()
 [![GitHub license](https://img.shields.io/github/license/scikit-sparse/scikit-sparse)](https://github.com/scikit-sparse/scikit-sparse/blob/master/LICENSE.txt)
 
@@ -30,6 +30,16 @@ sudo apt-get install libsuitesparse-dev
 Then, `scikit-sparse` can be installed via pip:
 ```bash
 pip install scikit-sparse
+```
+
+If you suite-sparse library is installed in a non-standard place and you get errors when installing with `pip` you can use the environment
+variables:
+* `SUITESPARSE_INCLUDE_DIR`
+* `SUITESPARSE_LIBRARY_DIR`
+
+at runtime so the compiler can find them. For example, lets say your suite-sparse installation is in `/opt/local` then you can run
+```bash
+SUITESPARSE_INCLUDE_DIR=/opt/local/include SUITESPARSE_LIBRARY_DIR=/opt/local/lib pip install scikit-sparse
 ```
 
 ### With `conda`

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@
 # 2016-2017   Joscha Reimer           <jor@informatik.uni-kiel.de>
 # 2021-       Justin Ellis            <justin.ellis18@gmail.com>
 
-"""Sparse matrix tools. 
+"""Sparse matrix tools.
 
 This is a home for sparse matrix code in Python that plays well with
 scipy.sparse, but that is somehow unsuitable for inclusion in scipy
@@ -20,6 +20,13 @@ So far we have a wrapper for the CHOLMOD library for sparse Cholesky
 decomposition. Further contributions are welcome!
 """
 
+import os
+import sys
+
+import numpy as np
+from Cython.Build import cythonize
+from setuptools import Extension, find_packages, setup
+
 DISTNAME = "scikit-sparse"
 DESCRIPTION = "Scikit sparse matrix package"
 LONG_DESCRIPTION = __doc__
@@ -28,11 +35,23 @@ MAINTAINER_EMAIL = "justin.ellis18@gmail.com"
 URL = "https://github.com/scikit-sparse/scikit-sparse"
 LICENSE = "BSD"
 
-import sys
 
-import numpy as np
-from Cython.Build import cythonize
-from setuptools import Extension, find_packages, setup
+INCLUDE_DIRS = [
+    np.get_include(),
+    sys.prefix + "/include",
+    # Debian's suitesparse-dev installs to
+    # /usr/include/suitesparse
+    "/usr/include/suitesparse",
+]
+LIBRARY_DIRS = []
+
+user_include_dir = os.getenv("SUITESPARSE_INCLUDE_DIR")
+user_library_dir = os.getenv("SUITESPARSE_LIBRARY_DIR")
+if user_include_dir:
+    INCLUDE_DIRS.append(user_include_dir)
+
+if user_library_dir:
+    LIBRARY_DIRS.append(user_library_dir)
 
 setup(
     install_requires=["numpy>=1.13.3", "scipy>=0.19"],
@@ -70,14 +89,8 @@ setup(
         Extension(
             "sksparse.cholmod",
             ["sksparse/cholmod.pyx"],
-            include_dirs=[
-                np.get_include(),
-                sys.prefix + "/include",
-                # Debian's suitesparse-dev installs to
-                # /usr/include/suitesparse
-                "/usr/include/suitesparse",
-            ],
-            library_dirs=[],
+            include_dirs=INCLUDE_DIRS,
+            library_dirs=LIBRARY_DIRS,
             libraries=["cholmod"],
         )
     ),


### PR DESCRIPTION
This PR implements a few changes in the way suite-sparse is found on installation. Previously the include and library paths were hardcocded. Now they can be controlled through environment variables:

If you suite-sparse library is installed in a non-standard place and you get errors when installing with `pip` you can use the environment
variables:
* `SUITESPARSE_INCLUDE_DIR`
* `SUITESPARSE_LIBRARY_DIR`

at runtime so the compiler can find them. For example, lets say your suite-sparse installation is in `/opt/local` then you can run
```bash
SUITESPARSE_INCLUDE_DIR=/opt/local/include SUITESPARSE_LIBRARY_DIR=/opt/local/lib pip install scikit-sparse
```

This should fix #67 