### PR TITLE
Fix import in setup.py to avoid distutils.errors.DistutilsSetupError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,8 @@ import os
 import sys
 
 import numpy as np
-from Cython.Build import cythonize
 from setuptools import Extension, find_packages, setup
+from Cython.Build import cythonize
 
 DISTNAME = "scikit-sparse"
 DESCRIPTION = "Scikit sparse matrix package"


### PR DESCRIPTION
See https://github.com/conda-forge/scikit-sparse-feedstock/pull/32 and https://stackoverflow.com/questions/21594925/error-each-element-of-ext-modules-option-must-be-an-extension-instance-or-2-t.

