### PR TITLE
Support for 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,12 +23,13 @@ exclude = '''
 [build-system]
 requires = [
     "setuptools>=40.8.0",
-    "wheel", 
+    "wheel",
     "Cython>=0.22",
     'numpy==1.13.3; python_version=="3.6"',
     'numpy==1.14.5; python_version=="3.7"',
     'numpy==1.17.3; python_version=="3.8"',
     'numpy==1.19.3; python_version=="3.9"',
     'numpy==1.23.1; python_version=="3.10"',
+    'numpy==1.23.5; python_version=="3.11"',
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ if user_library_dir:
 
 setup(
     install_requires=["numpy>=1.13.3", "scipy>=0.19"],
-    python_requires=">=3.6, <3.11",
+    python_requires=">=3.6, <4.0",
     packages=find_packages(),
     package_data={
         "": ["test_data/*.mtx.gz"],


### PR DESCRIPTION
This PR increments various versions in order that `scikit-sparse` be available in Python 3.11. I verified that I was able to run the tests in the `test` directory without error.