### PR TITLE
Constrain cython version to < 3.0.0 to avoid compilation error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ exclude = '''
 requires = [
     "setuptools>=40.8.0",
     "wheel", 
-    "Cython>=0.22",
+    "Cython>=0.22,<3.0.0",
     'numpy==1.13.3; python_version=="3.6"',
     'numpy==1.14.5; python_version=="3.7"',
     'numpy==1.17.3; python_version=="3.8"',


### PR DESCRIPTION
Quick fix to enable installation again, which previously failed due to new release of Cython. Doesn't fix the underlying error described in #91.