### PR TITLE
Fix compilation with Cython>=3.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,8 @@ exclude = '''
 [build-system]
 requires = [
     "setuptools>=40.8.0",
-    "wheel", 
-    "Cython>=0.22,<3.0.0",
+    "wheel",
+    "Cython>=0.22",
     'numpy==1.13.3; python_version=="3.6"',
     'numpy==1.14.5; python_version=="3.7"',
     'numpy==1.17.3; python_version=="3.8"',

--- a/sksparse/cholmod.pyx
+++ b/sksparse/cholmod.pyx
@@ -39,6 +39,7 @@
 
 #cython: binding = True
 #cython: language_level = 3
+#cython: legacy_implicit_noexcept = True
 
 cimport numpy as np
 


### PR DESCRIPTION
This seems to fix compilation for Cython3 and should not impact builds on previous versions.
See https://cython.readthedocs.io/en/latest/src/userguide/migrating_to_cy30.html#exception-values-and-noexcept