### PR TITLE
Fix breaking changes in isspmatrix of scipy >=1.11.0, discontinuing compatibility with csc_array

### DIFF
--- a/sksparse/cholmod.pyx
+++ b/sksparse/cholmod.pyx
@@ -403,12 +403,12 @@ cdef void _error_handler(
         warnings.warn(full_msg, CholmodWarning)
 
 def _check_for_csc(m):
-    if not sparse.isspmatrix_csc(m):
+    if not sparse.isspmatrix_csc(m) or (hasattr(sparse, "csc_array") and isinstance(m, sparse.csc_array)):
         warnings.warn("converting matrix of class %s to CSC format"
                       % (m.__class__.__name__,),
                       CholmodTypeConversionWarning)
         m = m.tocsc()
-    assert sparse.isspmatrix_csc(m)
+    assert sparse.isspmatrix_csc(m) or (hasattr(sparse, "csc_array") and isinstance(m, sparse.csc_array))
     return m
 
 cdef class Common:


### PR DESCRIPTION
Details see https://github.com/scipy/scipy/pull/18528

Previously it worked fine with `csc_array` and `csc_matrix`, but changes in scipy ( https://github.com/scipy/scipy/pull/18528 ) made breaking changes to `isspmatrix`, discontinuing compatibility with `csc_array`.

This PR fixed this.