### PR TITLE
remove numpy build restrictions, add Python 3.12 build to github action

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, macos-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - name: Checkout repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,11 +25,6 @@ requires = [
     "setuptools>=40.8.0",
     "wheel",
     "Cython>=0.22",
-    'numpy==1.13.3; python_version=="3.6"',
-    'numpy==1.14.5; python_version=="3.7"',
-    'numpy==1.17.3; python_version=="3.8"',
-    'numpy==1.19.3; python_version=="3.9"',
-    'numpy==1.23.1; python_version=="3.10"',
-    'numpy==1.23.5; python_version=="3.11"',
+    'numpy>=1.13.3; python_version>="3.6"',
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ if user_library_dir:
 
 setup(
     install_requires=["numpy>=1.13.3", "scipy>=0.19"],
-    python_requires=">=3.6, <3.12",
+    python_requires=">=3.6",
     packages=find_packages(),
     package_data={
         "": ["test_data/*.mtx.gz"],


### PR DESCRIPTION
- Adds Python 3.12 to the testing matrix.
- Removes pinning of the numpy version for different Python versions. There is no such restriction at runtime. It is not clear to me if there is a reason for keeping these restrictions around.