### PR TITLE
Fix incorrect installation instruction in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ variables:
 
 at runtime so the compiler can find them. For example, lets say your suite-sparse installation is in `/opt/local` then you can run
 ```bash
-SUITESPARSE_INCLUDE_DIR=/opt/local/include SUITESPARSE_LIBRARY_DIR=/opt/local/lib pip install scikit-sparse
+SUITESPARSE_INCLUDE_DIR=/opt/local/include/suitesparse SUITESPARSE_LIBRARY_DIR=/opt/local/lib pip install scikit-sparse
 ```
 
 ### With `conda`


### PR DESCRIPTION
As per [SuiteSparse README](https://github.com/DrTimothyAldenDavis/SuiteSparse/blob/dev/README.md), the default install location for include files is `CMAKE_INSTALL_PREFIX/include/suitesparse/`, not `CMAKE_INSTALL_PREFIX/include/`. Therefore, `pip install` with `SUITESPARSE_INCLUDE_DIR={YOUR_SUITESPARSE_INSTALLATION_ROOT}/include/` will fail because it won't find `cholmod.h`.