### PR TITLE
Bump up numpy requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,11 @@ requires = [
     "setuptools>=40.8.0",
     "wheel",
     "Cython>=0.22",
-    'numpy>=1.13.3; python_version>="3.6"',
+    'numpy>=1.13.3; python_version=="3.6"',
+    'numpy>=1.14.5; python_version=="3.7"',
+    'numpy>=1.17.3; python_version=="3.8"',
+    'numpy>=1.19.3; python_version=="3.9"',
+    'numpy>=1.23.1; python_version=="3.10"',
+    'numpy>=1.23.5; python_version>="3.11"',
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
See #116.

This restores the minimum numpy requirements to before #105. It does not reintroduce the Python version restriction that was the main motivation for #105.