### PR TITLE
make python 3.6, 3.7 run on old Mac version

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
         exclude:  # Python < v3.8 does not support Apple Silicon ARM64.
           - python-version: "3.6"
             os: macos-latest

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -23,11 +23,15 @@ jobs:
             os: macos-latest
           - python-version: "3.7"
             os: macos-latest
+          - python-version: "3.6"
+            os: ubuntu-latest
         include:  # So run those legacy versions on Intel CPUs.
           - python-version: "3.6"
             os: macos-13
           - python-version: "3.7"
             os: macos-13
+          - python-version: "3.6"
+            os: ubuntu-20.04
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -16,8 +16,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        exclude:  # Python < v3.8 does not support Apple Silicon ARM64.
+          - python-version: "3.6"
+            os: macos-latest
+          - python-version: "3.7"
+            os: macos-latest
+        include:  # So run those legacy versions on Intel CPUs.
+          - python-version: "3.6"
+            os: macos-13
+          - python-version: "3.7"
+            os: macos-13
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
Old versions of Python don't have support on the new Mac architecture. This is a workaround for CI purposes.