### PR TITLE
Make upload directory match build directory in deployment

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -118,6 +118,6 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: dist
-        path: dist
+        path: dist/*
     - name: Build and publish
       uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
`dist/*` is missing in the deployment part of CI. Previously this was `dist` instead of `dist/*` which was used in the build step.