### PR TITLE
Switch to csc_matrix.T.conjugate() from .H

### DIFF
--- a/tests/test_cholmod.py
+++ b/tests/test_cholmod.py
@@ -94,7 +94,7 @@ def complex_matrix():
 
 def factor_of(factor, matrix):
     return np.allclose(
-        (factor.L() * factor.L().H).todense(), matrix.todense()[factor.P()[:, np.newaxis], factor.P()[np.newaxis, :]]
+        (factor.L() * factor.L().T.conjugate()).todense(), matrix.todense()[factor.P()[:, np.newaxis], factor.P()[np.newaxis, :]]
     )
 
 


### PR DESCRIPTION
With scipy 1.14 csc_matrix.H has been removed, after being deprecated in 1.12. T.conjugate() is the replacement method, switch to it.

This might require bumping the minimum required version of scipy, I am not certain when `T.conjugate()` was added.