### PR TITLE
Fixed a bug in CSC format checking

### DIFF
--- a/sksparse/cholmod.pyx
+++ b/sksparse/cholmod.pyx
@@ -403,7 +403,7 @@ cdef void _error_handler(
         warnings.warn(full_msg, CholmodWarning)
 
 def _check_for_csc(m):
-    if not sparse.isspmatrix_csc(m) or (hasattr(sparse, "csc_array") and isinstance(m, sparse.csc_array)):
+    if not (sparse.isspmatrix_csc(m) or (hasattr(sparse, "csc_array") and isinstance(m, sparse.csc_array))):
         warnings.warn("converting matrix of class %s to CSC format"
                       % (m.__class__.__name__,),
                       CholmodTypeConversionWarning)


### PR DESCRIPTION
The boolean check is actually `not A or (B and C)`, should be `not (A or (B and C))`