### PR TITLE
Update CI and add Python 3.13 support

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -115,7 +115,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
     - name: Download wheel/dist from build
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: dist
         path: dist

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -25,13 +25,17 @@ jobs:
             os: macos-latest
           - python-version: "3.6"
             os: ubuntu-latest
+          - python-version: "3.7"
+            os: ubuntu-latest
         include:  # So run those legacy versions on Intel CPUs.
           - python-version: "3.6"
             os: macos-13
           - python-version: "3.7"
             os: macos-13
           - python-version: "3.6"
-            os: ubuntu-20.04
+            os: ubuntu-22.04
+          - python-version: "3.7"
+            os: ubuntu-22.04
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -16,26 +16,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, macos-latest]
-        exclude:  # Python < v3.8 does not support Apple Silicon ARM64.
-          - python-version: "3.6"
-            os: macos-latest
-          - python-version: "3.7"
-            os: macos-latest
-          - python-version: "3.6"
-            os: ubuntu-latest
-          - python-version: "3.7"
-            os: ubuntu-latest
-        include:  # So run those legacy versions on Intel CPUs.
-          - python-version: "3.6"
-            os: macos-13
-          - python-version: "3.7"
-            os: macos-13
-          - python-version: "3.6"
-            os: ubuntu-22.04
-          - python-version: "3.7"
-            os: ubuntu-22.04
 
     steps:
     - name: Checkout repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,5 +32,6 @@ requires = [
     'numpy>=2.0; python_version=="3.10"',
     'numpy>=2.0; python_version>="3.11"',
     'numpy>=2.0; python_version>="3.12"',
+    'numpy>=2.0; python_version>="3.13"',
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ DISTNAME = "scikit-sparse"
 DESCRIPTION = "Scikit sparse matrix package"
 LONG_DESCRIPTION = __doc__
 MAINTAINER = "Aaron Johnson"
-MAINTAINER_EMAIL = "justin.ellis18@gmail.com"
+MAINTAINER_EMAIL = "aaron9035@gmail.com"
 URL = "https://github.com/scikit-sparse/scikit-sparse"
 LICENSE = "BSD"
 
@@ -83,7 +83,6 @@ setup(
         "": ["test_data/*.mtx.gz"],
     },
     name=DISTNAME,
-
     version="0.4.16",  # remember to update __init__.py
     maintainer=MAINTAINER,
     maintainer_email=MAINTAINER_EMAIL,


### PR DESCRIPTION
Ubuntu 20.04 was removed from Actions last week. This PR

* Updates the version number to 4.16
* Changes maintainer email
* Removes 3.6, 3.7 from CI. 3.6 has no corresponding Ubuntu version that is supported (3.7 will follow soon).
* Adds corresponding numpy version (>=2) for Python 3.13
* Adds tests for Python 3.13 to CI